### PR TITLE
ExplanationOfBenefitItemDetail sequence not required

### DIFF
--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -4,7 +4,7 @@ import logging
 
 from server import FHIRServer, FHIRUnauthorizedException, FHIRNotFoundException
 
-__version__ = '3.2.0-clover-3'
+__version__ = '3.2.0-clover-4'
 __author__ = 'SMART Platforms Team'
 __license__ = 'APACHE2'
 __copyright__ = "Copyright 2017 Boston Children's Hospital"

--- a/fhirclient/models/explanationofbenefit.py
+++ b/fhirclient/models/explanationofbenefit.py
@@ -1034,7 +1034,7 @@ class ExplanationOfBenefitItemDetail(backboneelement.BackboneElement):
             ("programCode", "programCode", codeableconcept.CodeableConcept, True, None, False),
             ("quantity", "quantity", quantity.Quantity, False, None, False),
             ("revenue", "revenue", codeableconcept.CodeableConcept, False, None, False),
-            ("sequence", "sequence", int, False, None, True),
+            ("sequence", "sequence", int, False, None, False),
             ("service", "service", codeableconcept.CodeableConcept, False, None, False),
             ("subDetail", "subDetail", ExplanationOfBenefitItemDetailSubDetail, True, None, False),
             ("type", "type", codeableconcept.CodeableConcept, False, None, True),


### PR DESCRIPTION
Sample EOB response from CMS if failing because details within an item are missing `sequence`. We don't use details, so this is not super relevant for us at the moment.